### PR TITLE
Support QUOTED-PRINTABLE fields

### DIFF
--- a/org-vcard.el
+++ b/org-vcard.el
@@ -226,7 +226,7 @@
 
 (require 'org)
 (require 'org-element)
-
+(require 'subr-x)
 
 ;;
 ;; Setup.

--- a/org-vcard.el
+++ b/org-vcard.el
@@ -896,10 +896,9 @@ SOURCE must be one of \"file\", \"buffer\" or \"region\"."
                           (setq property (replace-match "" nil nil property))))
               charset (cdr (assoc-string charset org-vcard-character-set-mapping :case-fold))
               encoding (when (string-match ";ENCODING=\\([^;:]+\\)" property)
-                         (prog1 (match-string-no-properties 1 property) ; Save the value of the encoding.
+                         (prog1 (upcase (match-string-no-properties 1 property)) ; Save the value of the encoding.
                            ;; Remove the encoding from the property name:
-                           (setq property (replace-match "" nil nil property))))
-              encoding (upcase encoding))
+                           (setq property (replace-match "" nil nil property)))))
         ;; Consume value and continuation lines:
         (while (progn ; Idiomatic do-while loop.
                  ;; Add the text from the current point to the end of the the line (minus line ending) to the value:

--- a/org-vcard.el
+++ b/org-vcard.el
@@ -865,8 +865,8 @@ of that property in the cdr.
 SOURCE must be one of \"file\", \"buffer\" or \"region\"."
   (let ((property "")
         (value "")
-        charset
-        encoding
+        (charset "")
+        (encoding "")
         (cards '())
         (current-card '()))
     (cond

--- a/org-vcard.el
+++ b/org-vcard.el
@@ -894,7 +894,7 @@ SOURCE must be one of \"file\", \"buffer\" or \"region\"."
                         (prog1 (match-string-no-properties 1 property) ; Save the value of the charset.
                           ;; Remove the charset from the property name:
                           (setq property (replace-match "" nil nil property))))
-              charset (cdr (assoc-string charset org-vcard-character-set-mapping))
+              charset (cdr (assoc-string charset org-vcard-character-set-mapping :case-fold))
               encoding (when (string-match ";ENCODING=\\([^;:]+\\)" property)
                          (prog1 (match-string-no-properties 1 property) ; Save the value of the encoding.
                            ;; Remove the encoding from the property name:

--- a/org-vcard.el
+++ b/org-vcard.el
@@ -1,8 +1,10 @@
 ;;; org-vcard.el --- org-mode support for vCard export and import.
 
-;; Copyright (C) 2014-2017  Alexis <flexibeast@gmail.com>
+;; Copyright (C) 2014-2019  Alexis <flexibeast@gmail.com>
+;;                          Will Dey <will123dey@gmail.com>
 
 ;; Author: Alexis <flexibeast@gmail.com>
+;;         Will Dey <will123dey@gmail.com>
 ;; Maintainer: Alexis <flexibeast@gmail.com>
 ;; Created: 2014-07-31
 ;; URL: https://github.com/flexibeast/org-vcard

--- a/org-vcard.el
+++ b/org-vcard.el
@@ -884,8 +884,6 @@ SOURCE must be one of \"file\", \"buffer\" or \"region\"."
       (setq current-card '())
       (forward-line)
       (while (not (looking-at "END:VCARD"))
-        (setq current-line
-              (buffer-substring-no-properties (line-beginning-position) (line-end-position)))
         (re-search-forward "^\\([^:]+\\): *")
         ;; Parse property:
         (setq property (match-string-no-properties 1)

--- a/tests/org-vcard-tests.el
+++ b/tests/org-vcard-tests.el
@@ -515,7 +515,13 @@ vCard 2.1."
             (insert "NOTE:A\u000D\u000A  multiline\u000D\u000A\u0009 comment.\u000D\u000A")
             (insert "END:VCARD\u000D\u000A")
             (equal '((("NOTE" . "A multiline comment.")))
-                   (org-vcard-import-parse "buffer")))))
+                   (org-vcard-import-parse "buffer"))))
+  (should (with-temp-buffer
+	    (insert "BEGIN:vcard\u000D\u000A")
+	    (insert "NOTE;CHARSET=UTF-8;ENCODING=QUOTED-PRINTABLE:=65=6E=63=6F=64=65=64\u000D\u000A")
+	    (insert "END:VCARD\u000D\u000A")
+	    (equal '((("NOTE" . "encoded")))
+		   (org-vcard-import-parse "buffer")))))
 
 
 (ert-deftest org-vcard-test-transfer-write ()


### PR DESCRIPTION
Contact exports on Android use and [`ENCODING=QUOTED-PRINTABLE`](https://en.wikipedia.org/wiki/Quoted-printable) encoding for folded lines, text with line breaks, and non-ASCII characters. These end up all over my export files.

Thankfully Emacs has built-in with support for encoded/decoding quoted-printable in the `qp` feature. This PR adds support for decoding such fields properly, loading the `qp` feature only when necessary.

`org-vcard-import-parse` was reworked in the process while keeping the same functionality. Some duplicate regexes have been consolidated and the `append` that was bringing the overall time to O(n<sup>2</sup>) has been switched to O(n) [`push` + `nreverse`](https://nullprogram.com/blog/2017/01/30/#2-prefer-built-in-functions). Feel free to change the comment indentation.

All tests pass, and another has been added for quoted-printable