### PR TITLE
fix error when card has no heading (FN or N)

### DIFF
--- a/styles/flat/functions.el
+++ b/styles/flat/functions.el
@@ -116,10 +116,10 @@ DESTINATION must be one of \"buffer\" or \"file\"."
           (setq org-vcard-active-version org-vcard-default-version))
         (setq heading
               (or (cdr (assoc org-vcard-default-property-for-heading card))
-                  (replace-regexp-in-string "^;\\|;$" ""
-                                            (cdr (assoc (if (string= org-vcard-default-property-for-heading "FN")
-                                                            "N"
-                                                          "FN") card)))))
+                  (cdr (assoc (if (string= org-vcard-default-property-for-heading "FN")
+                                  "N"
+                                "FN") card))
+                  "NO TITLE"))
         (setq content (concat content
                               "* " heading "\n"
                               ":PROPERTIES:\n"))


### PR DESCRIPTION
Currently, when a vcard has no heading (which can happen e.g. when exporting from 'google contacts'), the importer crashes with the following message:
```
Debugger entered--Lisp error: (wrong-type-argument arrayp nil)
replace-regexp-in-string("^;\\|;$" "" nil)
```
etc.

This PR fixes the issue and gives the vcard without heading, a "NO TITLE" heading in the .org file